### PR TITLE
Fix image links and use icon-24 instead of icon-64

### DIFF
--- a/.github/workflows/generate-applist.yml
+++ b/.github/workflows/generate-applist.yml
@@ -17,6 +17,8 @@ jobs:
           git config user.email 'ryanfortner@users.noreply.github.com'
           git clone https://github.com/Botspot/pi-apps.wiki.git && cp ./pi-apps.wiki/Apps-List.md ./docs/apps-list.md && rm -rf pi-apps.wiki
           sed -i '1s/^/# Apps List\n/' ./docs/apps-list.md
+          sed -i 's/blob/raw/' ./docs/apps-list.md
+          sed -i 's/icon-64/icon-24/' ./docs/apps-list.md
           git add .
           git commit -m "[auto] update appslist"
           git push origin master


### PR DESCRIPTION
The link for the github images are broken due to which the images are not rendered in the mkdocs page. I have fixed that with a sed command. Also I felt that the the icon-64 was too large so I changed it to icon-24. I have used a sed command to do that too.